### PR TITLE
Add coveralls integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ before_install:
 
 install: npm install
 
-script: grunt 
+script: grunt with_coverage
+
+after_success: grunt coveralls

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,6 +38,10 @@ module.exports = function(grunt) {
             'dist/jose-jwe.js': ['coverage']
           },
           reporters: ['coverage'],
+          coverageReporter: {
+            type : 'lcovonly',
+            dir : 'coverage/'
+          },
           frameworks: ['qunit'],
           files: [
             {pattern: 'dist/jose-jwe.js', watching: false, included: false},
@@ -53,7 +57,7 @@ module.exports = function(grunt) {
             }
           },
           singleRun: true,
-          plugins:[ 'karma-coverage', 'karma-qunit', 'karma-chrome-launcher']
+          plugins:['karma-coverage', 'karma-qunit', 'karma-chrome-launcher']
         }
       },
       without_coverage: {
@@ -75,6 +79,15 @@ module.exports = function(grunt) {
           singleRun: true
         }
       }
+    },
+
+    coveralls: {
+      options: {
+        debug: true,
+        coverageDir: 'coverage',
+        force: true,
+        recursive: true
+      }
     }
   };
 
@@ -89,6 +102,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-karma');
+  grunt.loadNpmTasks('grunt-karma-coveralls');
 
   grunt.registerTask('default', ['jshint', 'concat', 'uglify', 'karma:without_coverage']);
   grunt.registerTask('with_coverage', ['jshint', 'concat', 'uglify', 'karma:with_coverage']);

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Javascript library for Jose JWE
 ===============================
 
-[![license](http://img.shields.io/badge/license-apache_2.0-red.svg?style=flat)](https://raw.githubusercontent.com/square/js-jose/master/LICENSE) [![build](https://img.shields.io/travis/square/js-jose.svg?style=flat)](https://travis-ci.org/square/js-jose)
+[![license](http://img.shields.io/badge/license-apache_2.0-red.svg?style=flat)](https://raw.githubusercontent.com/square/js-jose/master/LICENSE) [![build](https://img.shields.io/travis/square/js-jose.svg?style=flat)](https://travis-ci.org/square/js-jose) [![coverage](https://img.shields.io/coveralls/square/js-jose.svg?style=flat)](https://coveralls.io/r/square/js-jose)
 
 Overview
 --------

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "url": "https://github.com/square/js-jose.git"
   },
   "devDependencies": {
+    "coveralls": "^2.11.1",
     "grunt": "~0.4.1",
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-karma": "^0.9.0",
+    "grunt-karma-coveralls": "^2.5.3",
     "karma": "^0.12.28",
     "karma-chrome-launcher": "^0.1.5",
     "karma-coverage": "^0.2.7",


### PR DESCRIPTION
Add coveralls integration to show test coverage information.

See build: https://travis-ci.org/square/js-jose/builds/50561777
And coveralls stats: https://coveralls.io/r/square/js-jose

R: @dgalling @alokmenghrajani 
