### PR TITLE
add VerifiableJws

### DIFF
--- a/lib/jose-jws-verify.js
+++ b/lib/jose-jws-verify.js
@@ -178,3 +178,36 @@ JoseJWS.Verifier.prototype.verify = function () {
   return Promise.all(promises);
 };
 
+/**
+ * A received JWS to be verified.
+ * @param cs string JWS in compact serialized format
+ * @returns VerifiableJws
+ * @constructor
+ */
+JoseJWS.VerifiableJws = function(cs) {
+  var parts = cs.split('.');
+  if (parts.length != 3) {
+    return Promise.reject(Error("VerifiableJws: invalid part count " + parts.length));
+  }
+  this.protected = parts[0];
+  this.payload = parts[1];
+  this.signature = parts[2];
+};
+
+/**
+ * Get protected headers as an object
+ * @returns Object protected headers of JWS
+ */
+JoseJWS.VerifiableJws.prototype.Headers = function() {
+  var jsonh = Utils.Base64Url.decode(this.protected);
+  var rv = JSON.parse(jsonh);
+  return rv;
+};
+
+/**
+ * Do not trust this unless signatures have been verified first.
+ * @returns string decoded payload of JWS
+ */
+JoseJWS.VerifiableJws.prototype.Payload = function() {
+  return Utils.Base64Url.decode(this.payload);
+};

--- a/lib/jose-jws-verify.js
+++ b/lib/jose-jws-verify.js
@@ -20,10 +20,12 @@
  * @param cryptographer  an instance of WebCryptographer (or equivalent). Keep
  *                       in mind that decryption mutates the cryptographer.
  * @param message        a JWS message
+ * @param keyfinder (optional) a function returning a Promise<CryptoKey> given
+ *                             a key id
  *
  * @author Patrizio Bruno <patrizio@desertconsulting.net>
  */
-JoseJWS.Verifier = function (cryptographer, message) {
+JoseJWS.Verifier = function (cryptographer, message, keyfinder) {
 
   var that = this,
     alg,
@@ -111,6 +113,10 @@ JoseJWS.Verifier = function (cryptographer, message) {
 
   that.key_promises = {};
   that.waiting_kid = 0;
+
+  if (keyfinder) {
+    that.keyfinder = keyfinder;
+  }
 };
 
 /**
@@ -160,8 +166,9 @@ JoseJWS.Verifier.prototype.verify = function () {
   var that = this,
     signatures = that.signatures,
     key_promises = that.key_promises,
+      keyfinder = that.keyfinder,
     promises = [],
-    check = Object.keys(that.key_promises).length > 0;
+      check = !!keyfinder || Object.keys(that.key_promises).length > 0;
 
   if (!check) {
     throw new Error("No recipients defined. At least one is required to verify the JWS.");
@@ -173,41 +180,10 @@ JoseJWS.Verifier.prototype.verify = function () {
 
   signatures.forEach(function (sig) {
     var kid = sig.protected.kid;
+    if (keyfinder) {
+      key_promises[kid] = keyfinder(kid);
+    }
     promises.push(that.cryptographer.verify(sig.aad, that.payload, sig.signature, key_promises[kid], kid));
   });
   return Promise.all(promises);
-};
-
-/**
- * A received JWS to be verified.
- * @param cs string JWS in compact serialized format
- * @returns VerifiableJws
- * @constructor
- */
-JoseJWS.VerifiableJws = function(cs) {
-  var parts = cs.split('.');
-  if (parts.length != 3) {
-    return Promise.reject(Error("VerifiableJws: invalid part count " + parts.length));
-  }
-  this.protected = parts[0];
-  this.payload = parts[1];
-  this.signature = parts[2];
-};
-
-/**
- * Get protected headers as an object
- * @returns Object protected headers of JWS
- */
-JoseJWS.VerifiableJws.prototype.Headers = function() {
-  var jsonh = Utils.Base64Url.decode(this.protected);
-  var rv = JSON.parse(jsonh);
-  return rv;
-};
-
-/**
- * Do not trust this unless signatures have been verified first.
- * @returns string decoded payload of JWS
- */
-JoseJWS.VerifiableJws.prototype.Payload = function() {
-  return Utils.Base64Url.decode(this.payload);
 };

--- a/test/jose-jws-test.html
+++ b/test/jose-jws-test.html
@@ -56,6 +56,93 @@
             }), true, "JWS message has been correctly verified");
 
         });
+
+        test("keyfinder", function(assert) {
+            var prvjwk = {
+                "alg": "RS256",
+                "d": "l0-Bq8hePldybBsBUon7eGgwD53XfzZNXKB9yq6V6DyOxpAP2KpASdCcTYlDWJb_tqdWSjqxDuWox0l6S3l-f6xjWu5Du1u0DATjzgtdGyrNw-yX0SZlVq_Nbotw0-0GT1VpyUmvNvCS_gy9tONDv4PIrfMe0fwaRoMFmVo40o18At6y4DMxWkH63wUTtXYFlGLH9dNd1yq4odIoqWYpA_aE0pxz1aGpqJzY0_-mXfB8oH-uAY6a474kAJV2PE25_mLxFRmT0qB-0qcpjoTn1SVQfMRaeWvh4YzU-o30mCKWmDgU5Obc0fK9buMoM3uQKFUkRNsCOg1o1_cjx6epsQ",
+                "dp": "R5dAKUQsBjKUCcoczkn5KOI3du5SU0F_p_2lpogHtR5vJcTZjluSm2lB7qgFheB80ZcVPtFiRN5h9A8qWmhHh5DIHibaQ0J_dVLH4CmmlKOBORzNJPicy54G99gsBzvTeqZ8_CYsrj1fRREMJxiHRk1uqe1VQ19nZQDZwrd8Q5E",
+                "dq": "pfXdH9NJdsMkKVUKruaw4K5jYONKVz499dbdTT8LgkkxoQy1Tvm_C1xJYO4KiK1qvjV9_jazqvGkvdxddPQOIc6bOmtm_UfSoMAdussi2spTK6eO5EAzDRcPfXqdgSc7ihjBdklma33q9iMhtIA2SE3IDG0QXswjKDfQ435n8Qk",
+                "e": "AQAB",
+                "ext": true,
+                "key_ops": ["sign"],
+                "kid": "76d4d722-4398-4fc4-a47e-df3d15de7fab",
+                "kty": "RSA",
+                "n": "xw6vxkASH4Jz23XLQMAj3FB55Dq4xCBwaTtUZpKSddMx3hvVeZb_nWv2Ogu18vL-x8LaYGYYG_LSirVA_tJ3ArEw_rqQDJOvsHTAuGrSOJkusJeC46Z5ZP0TndpunV6-04rxltjUVriwO8XzZdH4RnX_kSUEz3qeUc5j-OhTj59sG1-Os51iYiUEwDa6z8fn20wHRtEvPzG0MNQBX58CPuIM9bS8eNOZKUG-oVWAoWcbMfqEE5D8YsW_cZUWY9OLRa5C6xNRMfwlxYeMedJgehXJmxqaxSn0fe6-VZk9qcJDLiWg6vy1NYOJ8UOgtKtSPr7uL4Kc8K8akYVq-qHXAQ",
+                "p": "7ZYCLz4jFWW2ody4tPPOrDJn7dKXvkytUC6jL0_iGHNgjbcV3zEDkJC9eJWZaCXIwFKjnzlP4iQTHRqvE8pOFtHLaCj4MpEe9EIg6cZSoc866dVAD9aKS74TeCIQ5YBEvOAa_3h3Uecui0g_Xd0Hm3cr6VcNIMer2OffRmGTJcU",
+                "q": "1nw5av78m5eTQv9IgOuxzvy9NQfm2hw8eq2eBduYalIvpa_3QTWXzvJ7_iOomNzZyEm6AjmKQu1Ualfgqq5YDU-jKBY4Pd27SQXHFwO75dsOZc7Xn2QQbHLNNOL8vNSy9ZeEkvDJtwX1lJ9x9XLXztRqJZr_UqS5680zCPO__A0",
+                "qi": "Zv9pwzMgWoAFu9hwp-foLoCYaFdVGj8vV-QovqW507TzhRiZuaP9SsYEF5ZizhEDLtjSxX2KycQUt-EEP9piUvgPiF_K7zXmQ-clvh_qzXrOE4UhfXbAjLFCUBf8YcgFsCYzvvqom3ktxOC0FPhfJr7s2EXQIQjzK5Drm-fZTZc"
+            };
+            var pubjwk = {
+                "alg": "RS256",
+                "e": "AQAB",
+                "ext": true,
+                "key_ops": ["verify"],
+                "kid": "76d4d722-4398-4fc4-a47e-df3d15de7fab",
+                "kty": "RSA",
+                "n": "xw6vxkASH4Jz23XLQMAj3FB55Dq4xCBwaTtUZpKSddMx3hvVeZb_nWv2Ogu18vL-x8LaYGYYG_LSirVA_tJ3ArEw_rqQDJOvsHTAuGrSOJkusJeC46Z5ZP0TndpunV6-04rxltjUVriwO8XzZdH4RnX_kSUEz3qeUc5j-OhTj59sG1-Os51iYiUEwDa6z8fn20wHRtEvPzG0MNQBX58CPuIM9bS8eNOZKUG-oVWAoWcbMfqEE5D8YsW_cZUWY9OLRa5C6xNRMfwlxYeMedJgehXJmxqaxSn0fe6-VZk9qcJDLiWg6vy1NYOJ8UOgtKtSPr7uL4Kc8K8akYVq-qHXAQ"
+            };
+            var plaintext = "When you make the finding yourself - even if you're the last person on Earth to see the light - you'll never forget it. --Carl Sagan";
+
+            var pubjwks = {};
+            pubjwks[pubjwk.kid] = pubjwk;
+
+            var keyfinder = function (kid) {
+                var jwk = pubjwks[kid];
+                if (jwk) {
+                    return window.crypto.subtle.importKey("jwk", jwk,
+                            {name: "RSASSA-PKCS1-v1_5", hash: {name: "SHA-256"}},
+                            true, ['verify']);
+                } else {
+                    return Promise.reject(Error("unknown sender key id " + kid));
+                }
+            };
+
+            var cryptographer, signer;
+
+            assert.willEqual(window.crypto.subtle.importKey("jwk", prvjwk,
+                    {name: "RSASSA-PKCS1-v1_5", hash: {name: "SHA-256"}},
+                    true, ["sign"])
+                    .then(function (prvkey) {
+                        cryptographer = new Jose.WebCryptographer();
+                        cryptographer.setContentSignAlgorithm("RS256");
+                        signer = new JoseJWS.Signer(cryptographer);
+                        return signer.addSigner(prvkey, prvjwk.kid);
+                    })
+                    .then(function () {
+                        return signer.sign(plaintext);
+                    })
+                    .then(function (signed) {
+                        var verifier = new JoseJWS.Verifier(cryptographer, signed, keyfinder);
+                        return verifier.verify().then(function (result) {
+                            return result.filter(function (value) {
+                                        return !value.verified;
+                                    }).length == 0;
+                        });
+                    }),
+                    true, "keyfinder found key");
+
+            assert.wont(window.crypto.subtle.importKey("jwk", prvjwk,
+                    {name: "RSASSA-PKCS1-v1_5", hash: {name: "SHA-256"}},
+                    true, ["sign"])
+                    .then(function (prvkey) {
+                        cryptographer = new Jose.WebCryptographer();
+                        cryptographer.setContentSignAlgorithm("RS256");
+                        signer = new JoseJWS.Signer(cryptographer);
+                        return signer.addSigner(prvkey, "unknown");
+                    })
+                    .then(function () {
+                        return signer.sign(plaintext);
+                    })
+                    .then(function (signed) {
+                        var verifier = new JoseJWS.Verifier(cryptographer, signed, keyfinder);
+                        return verifier.verify().then(function (result) {
+                            return result.filter(function (value) {
+                                        return !value.verified;
+                                    }).length == 0;
+                        });
+                    }), "keyfinder rejected properly on unknown key");
+        });
     </script>
   </head>
   <body>


### PR DESCRIPTION
During my JWS verification workflow, I need to find the `kid` header in order to provide the proper public key for signature verification. I added some functionality as a `VerifiableJws` class that facilitates both retrieving headers and decoded payload from a JWS that has come in in compact serialized format. These objects are deliberately structured so that they can be passed to the constructor of `Verifier` in the `message` slot.
