### PR TITLE
restore serialization methods to SignedJws type

### DIFF
--- a/jose-jwe-jws.d.ts
+++ b/jose-jwe-jws.d.ts
@@ -84,6 +84,8 @@ export interface SignedJws {
     protected: string;
     payload: string;
     signature: string;
+    JsonSerialize(): Object;
+    CompactSerialize(): string;
 }
 
 export interface Signer {


### PR DESCRIPTION
If there is no objection, I would like to restore the methods for serialization to the `SignedJws` type that were removed in [this commit](https://github.com/square/js-jose/commit/6f76e72254bf2edac88cf8d1b5e16efc27795034).
