### PR TITLE
Do UCS2/UTF-8 conversion on JSON stringified objects, not just strings

### DIFF
--- a/dist/jose-commonjs.js
+++ b/dist/jose-commonjs.js
@@ -1496,7 +1496,7 @@ JoseJWS.Signer.prototype.sign = function(payload, aad, header) {
         if (message instanceof JWS) {
           toBeSigned = Utils.arrayFromString(Utils.Base64Url.decode(message.payload));
         } else if (message instanceof Object) {
-          toBeSigned = Utils.arrayFromString(JSON.stringify(message));
+          toBeSigned = Utils.arrayFromUtf8String(JSON.stringify(message));
         } else {
           throw new Error("cannot sign this message");
         }

--- a/dist/jose-testing.js
+++ b/dist/jose-testing.js
@@ -1499,7 +1499,7 @@ JoseJWS.Signer.prototype.sign = function(payload, aad, header) {
         if (message instanceof JWS) {
           toBeSigned = Utils.arrayFromString(Utils.Base64Url.decode(message.payload));
         } else if (message instanceof Object) {
-          toBeSigned = Utils.arrayFromString(JSON.stringify(message));
+          toBeSigned = Utils.arrayFromUtf8String(JSON.stringify(message));
         } else {
           throw new Error("cannot sign this message");
         }

--- a/dist/jose.js
+++ b/dist/jose.js
@@ -1501,7 +1501,7 @@ JoseJWS.Signer.prototype.sign = function(payload, aad, header) {
         if (message instanceof JWS) {
           toBeSigned = Utils.arrayFromString(Utils.Base64Url.decode(message.payload));
         } else if (message instanceof Object) {
-          toBeSigned = Utils.arrayFromString(JSON.stringify(message));
+          toBeSigned = Utils.arrayFromUtf8String(JSON.stringify(message));
         } else {
           throw new Error("cannot sign this message");
         }

--- a/lib/jose-jws-sign.js
+++ b/lib/jose-jws-sign.js
@@ -152,7 +152,7 @@ JoseJWS.Signer.prototype.sign = function(payload, aad, header) {
         if (message instanceof JWS) {
           toBeSigned = Utils.arrayFromString(Utils.Base64Url.decode(message.payload));
         } else if (message instanceof Object) {
-          toBeSigned = Utils.arrayFromString(JSON.stringify(message));
+          toBeSigned = Utils.arrayFromUtf8String(JSON.stringify(message));
         } else {
           throw new Error("cannot sign this message");
         }


### PR DESCRIPTION
Without this fix, passing objects to be signed that contain Unicode keys or values get mangled and cannot be unmarshalled properly later.