### PR TITLE
Pinning Terser version to fix minifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "karma-qunit": "^1.2.1",
     "qunit": "^1.0.0",
     "qunitjs": "^1.23.1",
+    "terser": "^3.14.1",
     "uglifyjs-webpack-plugin": "^2.0.1",
     "webpack": "^4.20.2",
     "webpack-cli": "^3.1.1"


### PR DESCRIPTION
The build is failing due to a Minifier issue.

> ERROR in jose.min.js from Terser
> TypeError: Cannot read property 'minify' of undefined

A change in the way Terser is exported is causing this issue.
https://github.com/terser-js/terser/pull/254
There is a fix in, this is a workaround while the fix peculates down the dependencies.