### PR TITLE
Update Travis CI set-up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: node_js
 node_js:
-  - 9.10.1
+  - "lts/*"
+  - "node"
 
-# Tests run in chromium
+addons:
+  chrome: stable
+
 before_install:
-  - export CHROME_BIN=chromium-browser
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - npm install -g grunt-cli
 
 install: npm install

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,10 +44,10 @@ module.exports = function(grunt) {
             'test/jose-jws-rsa-test.html'
           ],
           autoWatch: true,
-          browsers: ['Chrome'],
+          browsers: ['Chrome', 'ChromeHeadless', 'ChromeHeadlessNoSandbox'],
           customLaunchers: {
-            Chrome_travis_ci: {
-              base: 'Chrome',
+            ChromeHeadlessNoSandbox: {
+              base: 'ChromeHeadless',
               flags: ['--no-sandbox']
             }
           },
@@ -66,10 +66,10 @@ module.exports = function(grunt) {
             'test/jose-jws-rsa-test.html'
           ],
           autoWatch: true,
-          browsers: ['Chrome'],
+          browsers: ['Chrome', 'ChromeHeadless', 'ChromeHeadlessNoSandbox'],
           customLaunchers: {
-            Chrome_travis_ci: {
-              base: 'Chrome',
+            ChromeHeadlessNoSandbox: {
+              base: 'ChromeHeadless',
               flags: ['--no-sandbox']
             }
           },
@@ -89,8 +89,8 @@ module.exports = function(grunt) {
   };
 
   if (process.env.TRAVIS) {
-    config.karma.with_coverage.browsers = ['Chrome_travis_ci'];
-    config.karma.without_coverage.browsers = ['Chrome_travis_ci'];
+    config.karma.with_coverage.browsers = ['ChromeHeadlessNoSandbox'];
+    config.karma.without_coverage.browsers = ['ChromeHeadlessNoSandbox'];
   }
 
   grunt.initConfig(config);


### PR DESCRIPTION
- Updated Node.js versions in CI. The config now uses latest
  release and latest LTS version for testing.
- With updated Node.js versions, the implicitly set distribution
  changed, so rather than setting old Ubuntu version explicitly,
  the browser testing now uses headless Chrome, rather than intricate
  GUI set-up