### PR TITLE
Package using UMD to make it work in a Typescript/Webpack project

### DIFF
--- a/jose-jwe-jws.d.ts
+++ b/jose-jwe-jws.d.ts
@@ -94,6 +94,7 @@ interface IHeaders {
 interface IUtils {
     importRsaPublicKey(rsa_key: JWKRSA, alg: JoseAlgorithm): PromiseLike<CryptoKey>;
     importRsaPrivateKey(rsa_key: JWKRSA, alg: JoseAlgorithm): PromiseLike<CryptoKey>;
+    importPublicKey(key: IJsonWebKey, alg: JoseAlgorithm): PromiseLike<CryptoKey>;
 }
 
 interface IJose {
@@ -145,6 +146,10 @@ interface IDecrypter {
 interface IJoseJWE {
     Encrypter: IEncrypter;
     Decrypter: IDecrypter;
+}
+
+interface Window {
+    Jose: IJose;
 }
 
 declare function setCrypto(cryptoProvider: Crypto): void;

--- a/lib/jose-core.js
+++ b/lib/jose-core.js
@@ -45,11 +45,6 @@ const JoseJWS = {
   Verifier
 };
 
-const Jose = { JoseJWS, JoseJWE, WebCryptographer };
-
-export default { Jose, WebCryptographer };
-export { Jose, JoseJWE, JoseJWS, WebCryptographer };
-
 /**
  * Set crypto provider to use (window.crypto, node-webcrypto-ossl, node-webcrypto-pkcs11 etc.).
  */
@@ -68,6 +63,11 @@ if (typeof window !== 'undefined') {
     }
   }
 }
+
+const Jose = { JoseJWS, JoseJWE, WebCryptographer, crypto, Utils };
+
+export default { Jose, WebCryptographer };
+export { Jose, JoseJWE, JoseJWS, WebCryptographer };
 
 /**
  * Use Node versions of atob, btoa functions outside the browser

--- a/lib/jose-jwe-webcryptographer.js
+++ b/lib/jose-jwe-webcryptographer.js
@@ -15,9 +15,9 @@
  */
 
 // TODO(eslint): figure out how to properly include Jose or expose crypto object
-/* global Jose */
 
 import * as Utils from './jose-utils';
+import { Jose } from './jose-core';
 
 /**
  * The WebCryptographer uses http://www.w3.org/TR/WebCryptoAPI/ to perform

--- a/lib/jose-utils.js
+++ b/lib/jose-utils.js
@@ -15,9 +15,9 @@
  */
 
 // TODO(eslint): figure out how to properly include Jose or expose crypto object
-/* global Jose */
 
 import { WebCryptographer } from './jose-jwe-webcryptographer';
+import { Jose } from './jose-core';
 const webCryptographer = new WebCryptographer();
 
 /**

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -18,8 +18,8 @@ module.exports = {
 
   output: {
     filename: 'jose.min.js',
-    library:'Jose',
-    libraryTarget: 'var',
+    library: 'Jose',
+    libraryTarget: 'umd',
     path: path.resolve(__dirname, 'dist')
   },
 


### PR DESCRIPTION
I think this will fix #93. It worked in my local angular 8 project

Changed the library type to UMD.
> libraryTarget: 'umd' - This exposes your library under all the module
definitions, allowing it to work with CommonJS, AMD and as global
variable.

from https://webpack.js.org/configuration/output/#outputlibrarytarget